### PR TITLE
Podspec added

### DIFF
--- a/RNKeyboardManager.podspec
+++ b/RNKeyboardManager.podspec
@@ -1,0 +1,20 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+	s.name                = "RNKeyboardManager"
+	s.version         = version
+	s.description         = <<-DESC
+	This library allows to prevent issues of keyboard sliding up and cover on React-Native iOS projects
+	DESC
+	s.homepage            = "https://github.com/douglasjunior/react-native-keyboard-manager"
+	s.summary         = "A <ReactNativeKeyboardManager /> component for react-native"
+	s.license         = "MIT"
+	s.authors             = "Douglas Nassif Roma Junior"
+	s.source              = { :git => "https://github.com/douglasjunior/react-native-keyboard-manager.git", :tag => "v#{s.version}" }
+	s.platform            = :ios, "8.0"
+	s.preserve_paths      = 'README.md', 'package.json', '*.js'
+	s.source_files        = 'ios/ReactNativeKeyboardManager/**/*.{h,m}'
+	s.dependency          'React'
+	s.dependency          'IQKeyboardManager'
+end


### PR DESCRIPTION
Added a proper podspec for using with cocoapods. 

Actually, this is the only way to link the library with project without suffering and this shitty 
"<RCT***.h> not found" errors

Usage:
pod 'RNKeyboardManager', :path => '../node_modules/react-native-keyboard-manager'
![screen shot 2018-04-18 at 17 37 57](https://user-images.githubusercontent.com/5202281/38938860-431e42d2-432f-11e8-8810-e67756d140f6.png)