### PR TITLE
Fix crash `Exception 'accessing _cachedSystemAnimationFence requires …

### DIFF
--- a/ios/ReactNativeKeyboardManager/ReactNativeKeyboardManager.m
+++ b/ios/ReactNativeKeyboardManager/ReactNativeKeyboardManager.m
@@ -1,5 +1,5 @@
 // MIT License
-// 
+//
 // Copyright (c) 2017 Douglas Nassif Roma Junior
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -70,8 +70,10 @@ RCT_EXPORT_METHOD(setEnableDebugging: (BOOL) enabled) {
 // UIKeyboard handling
 
 RCT_EXPORT_METHOD(setEnable: (BOOL) enabled) {
-    if (debugging) RCTLogInfo(@"KeyboardManager.setEnable: %d", enabled);
-    [[IQKeyboardManager sharedManager] setEnable:enabled];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        if (debugging) RCTLogInfo(@"KeyboardManager.setEnable: %d", enabled);
+        [[IQKeyboardManager sharedManager] setEnable:enabled];
+    });
 }
 
 RCT_EXPORT_METHOD(setKeyboardDistanceFromTextField: (CGFloat) distance) {
@@ -96,8 +98,10 @@ RCT_EXPORT_METHOD(setPreventShowingBottomBlankSpace: (BOOL) enabled) {
 }
 
 RCT_EXPORT_METHOD(setEnableAutoToolbar: (BOOL) enabled) {
-    if (debugging) RCTLogInfo(@"KeyboardManager.setEnableAutoToolbar: %d", enabled);
-    [[IQKeyboardManager sharedManager] setEnableAutoToolbar:enabled];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        if (debugging) RCTLogInfo(@"KeyboardManager.setEnableAutoToolbar: %d", enabled);
+        [[IQKeyboardManager sharedManager] setEnableAutoToolbar:enabled];
+    });
 }
 
 RCT_EXPORT_METHOD(setShouldToolbarUsesTextFieldTintColor: (BOOL) enabled) {


### PR DESCRIPTION
Fix crash
```
Exception 'accessing _cachedSystemAnimationFence requires the main thread' was thrown while invoking setEnableAutoToolbar on target ReactNativeKeyboardManager with params (0)
```

![IMG_6542](https://user-images.githubusercontent.com/3401929/54306681-7fd12980-45fc-11e9-935d-f0a8d98f0cf4.PNG)
