### PR TITLE
Fix dependency declaration in ReactNativeKeyboardManager.podspec

### DIFF
--- a/ReactNativeKeyboardManager.podspec
+++ b/ReactNativeKeyboardManager.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 	s.preserve_paths = 'README.md', 'package.json', '*.js'
 	s.source_files   = 'ios/ReactNativeKeyboardManager/**/*.{h,m}'
 
-	s.dependency 'React'
+	s.dependency 'React-Core'
 	s.dependency 'React-RCTText'
 	s.dependency 'IQKeyboardManagerSwift', iqVersion
 end


### PR DESCRIPTION
Depending on 'React' target rather than 'React-Core' framework causes linker errors in projects that have use_frameworks! in their podfile.

Fixes #76