### PR TITLE
Add `setShouldToolbarUsesTextFieldTintColor` to TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module 'react-native-keyboard-manager' {
   export function setKeyboardAppearance(appearance: KeyboardAppearance);
   export function setShouldResignOnTouchOutside(enable: boolean);
   export function setShouldPlayInputClicks(enable: boolean);
+  export function setShouldToolbarUsesTextFieldTintColor(enable: boolean);
   export function resignFirstResponder();
   export function isKeyboardShowing(): Promise<boolean>;
 }


### PR DESCRIPTION
TS typings do not have `setShouldToolbarUsesTextFieldTintColor` function which is legit API function.